### PR TITLE
Update NaiveBayes.js to use Array.isArray

### DIFF
--- a/NaiveBayes.js
+++ b/NaiveBayes.js
@@ -45,7 +45,7 @@ NaiveBayes.prototype.learn = function (text, category) {
     var self = this;
     var texts = null;
     
-    if ('[object Array]' === Object.prototype.toString.call(text)) {
+    if (Array.isArray(text)) {
         texts = text;
     }
     else if ('string' === typeof text) {


### PR DESCRIPTION
Replace line 48 with something more meaningful. `Array` comes from JS 1.8.5 (ES5) standard.
